### PR TITLE
Renamed fields of stackoverflow_tags_popularity_in_questions_by_month and added percentages

### DIFF
--- a/definitions/stackoverflow_tags_popularity_in_questions_by_month.sqlx
+++ b/definitions/stackoverflow_tags_popularity_in_questions_by_month.sqlx
@@ -1,46 +1,41 @@
 config { type: "table" }
 
-WITH DATA AS(
-    WITH
-      questions AS (
-      SELECT
-        id,
-        SPLIT(tags, "|") AS splitted_tag,
-        score,
-      FROM
-        `bigquery-public-data.stackoverflow.posts_questions` ),
-      votes AS (
-      SELECT
+WITH tags_per_question AS(
+       SELECT
+        id, tag, creation_date
+        FROM
+        `bigquery-public-data.stackoverflow.posts_questions`
+        CROSS JOIN
+        UNNEST(SPLIT(`bigquery-public-data.stackoverflow.posts_questions`.tags, "|")) AS tag
+), upvote_events_per_post AS (
+        SELECT
         post_id,
-        creation_date AS vote_date,
+        FORMAT_DATE('%Y-%m', DATE(creation_date)) AS month,
       FROM
         `bigquery-public-data.stackoverflow.votes`
-       )
-    SELECT
-      id,
-      splitted_tag,
-      score,
-      vote_date,
-    FROM
-      questions
-    INNER JOIN
-      votes
-    ON
-      votes.post_id = questions.id )
-  SELECT
-    tag,
-    PARSE_DATE('%Y-%m-%d', FORMAT_DATE('%Y-%m-01', DATE(vote_date))) AS votes_date,
-    COUNT(*) AS count,
-    SUM(score) AS upvotes,
-    70 as percentage
+        WHERE vote_type_id=2 -- i.e. the vote is an upvote
+        
+), upvotes_per_tag_per_month AS (
+  SELECT tag,
+  month,
+  COUNT(*) AS upvotes_this_month,
   FROM
-    DATA
-  CROSS JOIN
-    UNNEST(data.splitted_tag) AS tag
+  upvote_events_per_post INNER JOIN tags_per_question ON tags_per_question.id = upvote_events_per_post.post_id
   GROUP BY
-    tag,
-    votes_date
-  ORDER BY
-    votes_date DESC,
-    count DESC,
-    upvotes DESC 
+  tag,
+  month
+), total_upvote_per_month AS (
+  SELECT month, sum(upvotes_this_month) as upvotes_for_all_tags
+  FROM upvotes_per_tag_per_month
+  GROUP BY month
+)
+select 
+  upvotes_per_tag_per_month.month, 
+  tag, 
+  upvotes_this_month, 
+  upvotes_this_month / upvotes_for_all_tags AS share_of_all_upvotes
+from upvotes_per_tag_per_month
+inner join total_upvote_per_month on upvotes_per_tag_per_month.month = total_upvote_per_month.month
+order by 
+upvotes_per_tag_per_month.month desc, 
+upvotes_this_month desc

--- a/definitions/stackoverflow_tags_popularity_in_questions_by_month.sqlx
+++ b/definitions/stackoverflow_tags_popularity_in_questions_by_month.sqlx
@@ -33,7 +33,7 @@ select
   upvotes_per_tag_per_month.month, 
   tag, 
   upvotes_this_month, 
-  upvotes_this_month / upvotes_for_all_tags AS share_of_all_upvotes
+  upvotes_this_month / upvotes_for_all_tags AS share_among_all_upvotes
 from upvotes_per_tag_per_month
 inner join total_upvote_per_month on upvotes_per_tag_per_month.month = total_upvote_per_month.month
 order by 


### PR DESCRIPTION
Solves #30 

For each tag, its share among the upvotes for the given month is contained in the field `share_among_all_upvotes`.  
I also made several changes for clarity purposes: 
- The field `count` has been renamed to `upvotes_this_month`. `count` implied the field contained the number of new questions for the tag for a given month. But it actually contained the number of votes for the tag on the month.
- The field `upvotes`  has been removed as it contains the cumulated score of questions for a tag at the time of the extraction. As this table is time-based the information was misleading. E.g. a record could contain `votes_date=March 2013, upvotes=1000` and the upvotes did not relate to March 2013 but to February 2024 (time of the extraction).
- The field `votes_date` has been replaced by `month` as it refers to a month rather than a date.
- The votes have been filtered: the previous query mistaked every _vote_ operation for an upvote. [It actually records all operations on a post](https://meta.stackexchange.com/questions/2677/database-schema-documentation-for-the-public-data-dump-and-sede) and most of them are moderation. By filtering on `vote_type_id=2` only upvotes are considered.  
  
Output : 
![image](https://github.com/Zenika/tendances-et-opportunites/assets/15016365/74866009-da78-4355-b3fa-ef6981738d4e)

